### PR TITLE
fix: move the rpm package to output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd ~
 mkdir gopath
 ```
 
-### run build tool script for apisix-dashboard (must use root privileges):
+### run build tool script for apisix-dashboard:
 ```
 ./dashboard-rpm.sh
 ```

--- a/dashboard-rpm.sh
+++ b/dashboard-rpm.sh
@@ -4,6 +4,7 @@ set -ex
 
 # set the code branch
 version=master
+curdir=$(pwd)
 
 # clear the environment
 rm -rf /tmp/apisix/
@@ -35,4 +36,6 @@ fpm -f \
     --url 'https://github.com/apache/apisix-dashboard'
 
 # copy rpm package to the `output`
-cp -r /tmp/rpm/* ~/output
+sleep 1
+cd $curdir
+cp -r /tmp/rpm/* ./output

--- a/dashboard-rpm.sh
+++ b/dashboard-rpm.sh
@@ -35,7 +35,7 @@ fpm -f \
     -p /tmp/rpm/ \
     --url 'https://github.com/apache/apisix-dashboard'
 
-# copy rpm package to the `output`
+# copy rpm package to the `output` directory
 sleep 1
 cd $curdir
 cp -r /tmp/rpm/* ./output

--- a/dashboard-rpm.sh
+++ b/dashboard-rpm.sh
@@ -26,16 +26,12 @@ cd ../..
 rm -rf apisix-dashboard
 
 # build the rpm for dashboard
+cd $curdir
 fpm -f \
     -s dir \
     -t rpm \
     -n apisix-dashboard -a `uname -i` -v $version  \
     --description 'Apache APISIX Dashboard is designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.'  \
     -C /tmp/apisix/dashboard/ \
-    -p /tmp/rpm/ \
+    -p ./output/ \
     --url 'https://github.com/apache/apisix-dashboard'
-
-# copy rpm package to the `output` directory
-sleep 1
-cd $curdir
-cp -r /tmp/rpm/* ./output


### PR DESCRIPTION
fix: move the rpm package to `output` directory